### PR TITLE
Support headers with multiple cookies

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,6 +1,6 @@
 {
   "name": "FastCGI::NativeCall",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "auth": "github:jonathanstowe",
   "api": "1.0",
   "description": "An implementation of FastCGI using NativeCall",

--- a/lib/FastCGI/NativeCall.rakumod
+++ b/lib/FastCGI/NativeCall.rakumod
@@ -247,7 +247,14 @@ class FastCGI::NativeCall {
     }
 
     multi method header(%header) {
-        my $header = %header.pairs.map( -> ( :$key, :$value ) { "$key: $value" }).join("\r\n") ~ "\r\n\r\n";
+        my $header = %header.pairs.map( -> ( :$key, :$value ) {
+            if $key ~~ m:i/^ 'Set-Cookie' $/ {
+                $value.map({ "$key: $_" }).join("\r\n");
+            }
+            else {
+                "$key: $value"
+            }
+        }).join("\r\n") ~ "\r\n\r\n";
         self.Print($header);
     }
 

--- a/t/020-cookies.t
+++ b/t/020-cookies.t
@@ -1,0 +1,72 @@
+use v6;
+
+use Test;
+use FastCGI::NativeCall;
+
+plan 2;
+
+class MockedFastCGI is FastCGI::NativeCall {
+    method Print(Str $in) returns Str {
+        return $in;
+    }
+}
+
+sub sock-path(--> Str) {
+    $*PID ~ '-' ~ now.Int ~ '.sock';
+}
+
+subtest {
+    my $path = sock-path();
+    my $fcgi = MockedFastCGI.new(:$path, backlog => 10);
+
+    my %header =
+        Content-Type => 'text/html; charset=UTF-8',
+        Accept => '*/*',
+        Content-length => 1982,
+        ETag => '33a64df551425fcc55e4d42a148795d9f25f89d4',
+        Set-Cookie => 'cookie1=1'
+    ;
+
+    my $printed_header = $fcgi.header(%header);
+
+    for %header.kv -> $key, $value {
+        ok $printed_header ~~ /"$key: $value\r\n"/, "header member $key";
+    }
+
+    LEAVE {
+        unlink($path);
+    }
+}, "check single cookie";
+
+subtest {
+    my $path = sock-path();
+    my $fcgi = MockedFastCGI.new(:$path, backlog => 10);
+
+    my %header =
+        Content-Type => 'text/html; charset=UTF-8',
+        Accept => '*/*',
+        Content-length => 1982,
+        ETag => '33a64df551425fcc55e4d42a148795d9f25f89d4',
+        Set-Cookie => ['cookie1=1', 'cookie2=2', 'cookieN=N']
+    ;
+
+    my $printed_header = $fcgi.header(%header);
+
+    for %header.kv -> $key, $value {
+        if $value ~~ Array {
+            $value.map({
+                my $member = $_;
+                ok $printed_header ~~ /"$key: $member\r\n"/, "header multiple member $key";
+            });
+        }
+        else {
+            ok $printed_header ~~ /"$key: $value\r\n"/, "header member $key";
+        }
+    }
+
+    LEAVE {
+        unlink($path);
+    }
+}, "check miltiple cookies";
+
+done-testing;


### PR DESCRIPTION
It's handy to be able to set a multiple cookies via HTTP header: https://datatracker.ietf.org/doc/html/rfc6265#section-3. I have added a quite straight-forward implementation with the simple tests.