### PR TITLE
Fix failure to find shared library after installation

### DIFF
--- a/lib/FastCGI/NativeCall.rakumod
+++ b/lib/FastCGI/NativeCall.rakumod
@@ -152,7 +152,7 @@ to use the C<close> method instead.
 
 
 class FastCGI::NativeCall {
-    my constant HELPER = %?RESOURCES<libraries/fcgi>.Str;
+    my constant HELPER = %?RESOURCES<libraries/fcgi>;
 
     class FCGX_Request is Pointer is repr('CPointer') { }
 


### PR DESCRIPTION
Precompilation during installation happens in a different location than the one the module is installed to. Resources can deal with this, but stringifying resources spoils this mechanism.